### PR TITLE
fix(version): synchronize package and MCP metadata

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -158,9 +158,11 @@ uv build
 
 ### Version Workflow
 
-1. Update version in `pyproject.toml`
-2. Update `CHANGELOG.md` with new version entry
-3. Commit changes
-4. Create and push tag
-5. Create GitHub release
-6. Workflow automatically publishes to PyPI
+1. Update the version once in `pyproject.toml`, the canonical version source.
+2. Run `uv lock` so the local package entry in `uv.lock` matches it.
+3. Update `CHANGELOG.md` with the same version entry.
+4. Run the version tests; the package and MCP initialization response derive
+   their version from installed distribution metadata and must match.
+5. Commit the changes and create the matching `vX.Y.Z` tag.
+6. Create the GitHub release; the workflow publishes that tagged version to
+   PyPI.

--- a/src/lunar_mcp_server/__init__.py
+++ b/src/lunar_mcp_server/__init__.py
@@ -5,9 +5,9 @@ A comprehensive MCP server providing traditional lunar calendar information,
 auspicious date checking, and festival data.
 """
 
-__version__ = "0.1.0"
 __author__ = "Lunar MCP Team"
 
+from ._version import __version__
 from .server import LunarMCPServer
 
-__all__ = ["LunarMCPServer"]
+__all__ = ["LunarMCPServer", "__version__"]

--- a/src/lunar_mcp_server/_version.py
+++ b/src/lunar_mcp_server/_version.py
@@ -1,0 +1,17 @@
+"""Runtime package version resolution."""
+
+from importlib import metadata
+
+DISTRIBUTION_NAME = "lunar-mcp-server"
+SOURCE_TREE_VERSION = "0+unknown"
+
+
+def resolve_version() -> str:
+    """Return installed distribution metadata or a deterministic source fallback."""
+    try:
+        return metadata.version(DISTRIBUTION_NAME)
+    except metadata.PackageNotFoundError:
+        return SOURCE_TREE_VERSION
+
+
+__version__ = resolve_version()

--- a/src/lunar_mcp_server/server.py
+++ b/src/lunar_mcp_server/server.py
@@ -19,6 +19,7 @@ from mcp.types import (
     Tool,
 )
 
+from ._version import __version__
 from .auspicious_dates import AuspiciousDateChecker
 from .bazi import BaZiCalculator
 from .calendar_conversions import CalendarConverter
@@ -30,7 +31,7 @@ class LunarMCPServer:
     """MCP Server for Lunar Calendar operations."""
 
     def __init__(self) -> None:
-        self.server = Server("lunar-mcp-server", version="0.1.0")
+        self.server = Server("lunar-mcp-server", version=__version__)
         self.lunar_calc = LunarCalculator()
         self.auspicious_checker = AuspiciousDateChecker()
         self.festival_manager = FestivalManager()

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,37 @@
+"""Tests for package and MCP runtime version synchronization."""
+
+from importlib import metadata
+
+from mcp.server.lowlevel import NotificationOptions
+
+from lunar_mcp_server import __version__
+from lunar_mcp_server import _version as version_module
+from lunar_mcp_server.server import LunarMCPServer
+
+
+def test_package_version_matches_installed_distribution() -> None:
+    """The public runtime version must come from installed package metadata."""
+    assert __version__ == metadata.version(version_module.DISTRIBUTION_NAME)
+
+
+def test_mcp_initialization_reports_package_version() -> None:
+    """MCP initialization metadata must expose the installed package version."""
+    server = LunarMCPServer().server
+    options = server.create_initialization_options(
+        notification_options=NotificationOptions()
+    )
+
+    assert server.version == __version__
+    assert options.server_version == __version__
+
+
+def test_source_tree_fallback_is_deterministic(monkeypatch) -> None:
+    """Source execution without distribution metadata uses a stable fallback."""
+
+    def missing_distribution(_: str) -> str:
+        raise metadata.PackageNotFoundError
+
+    monkeypatch.setattr(version_module.metadata, "version", missing_distribution)
+
+    assert version_module.resolve_version() == version_module.SOURCE_TREE_VERSION
+    assert version_module.SOURCE_TREE_VERSION == "0+unknown"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 
 [[package]]
@@ -433,7 +433,7 @@ wheels = [
 
 [[package]]
 name = "lunar-mcp-server"
-version = "1.1.0"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "astropy" },
@@ -1192,6 +1192,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/62/45/0e35398ef8d4b07ecfa9f7f680e183b2b6af9215a56af34f9e621c29b495/sgp4-2.25-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5789b7add136362684dfcbf0862919f8c3018f74ab11a05a9964edd5fdd4d2a7", size = 235584, upload-time = "2025-08-04T18:02:07.152Z" },
     { url = "https://files.pythonhosted.org/packages/47/b7/1b680b5514586b3860500109ef37fd1761f21e6787f20a2597baa44d91a0/sgp4-2.25-cp313-cp313-win32.whl", hash = "sha256:94219b486def29aa1246f42de8bea05ccb8e98a5458dd08ce42b9811c79ca814", size = 161896, upload-time = "2025-08-04T18:02:08.062Z" },
     { url = "https://files.pythonhosted.org/packages/67/c1/a22be2e7886db40d1512969f3b8cc3ce989167e69ea8f308f26afd1dfd31/sgp4-2.25-cp313-cp313-win_amd64.whl", hash = "sha256:dec2f6c842d9bf40c67d5764bd752980844f91f338020d2af7f85847364d0ff7", size = 164142, upload-time = "2025-08-04T18:02:09Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/47/8231e3d4a88341316ec8d0eb98d3a8a972477d8b038555259522735a8371/sgp4-2.25-py3-none-any.whl", hash = "sha256:4f39ecf6c2663109fed04adfe9982815ac83893271b521d92d5b186820f8c78e", size = 137376, upload-time = "2026-04-27T18:29:23.71Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- derive the public runtime version from installed distribution metadata
- use a deterministic `0+unknown` fallback when source-tree metadata is unavailable
- report the same version in MCP initialization metadata
- add divergence and fallback tests
- synchronize the stale local-package entry in `uv.lock`
- document `pyproject.toml` as the canonical release version source

## Validation
- `uv lock --check`
- `uv sync --frozen`
- `uv run black --check src tests`
- `uv run isort --check src tests`
- `uv run ruff check src tests`
- `uv run mypy src`
- `uv run pytest` (185 passed)

Closes #19
