### PR TITLE
chore(deps): upgrade Chinese calendar packages

### DIFF
--- a/docs/dependency-baseline-v1.2.1.md
+++ b/docs/dependency-baseline-v1.2.1.md
@@ -157,3 +157,13 @@ dependency and `uv audit --frozen` passes.
 - The duplicate dev declarations, duplicate MCP declaration, unused-direct
   candidates, shell portability failure, five MCP deprecation warnings, and
   vulnerability set are explicitly assigned to follow-up issues above.
+
+### #18 implementation outcome
+
+- Upgraded `lunardate` from 0.2.2 to 0.3.0 and `chinese-calendar` from 1.10.0
+  to 1.11.0.
+- Retained and pinned `zhdate` 0.1 because the published 1.0 sdist cannot be
+  resolved as version 1.0 by uv; replacement analysis is deferred.
+- Added exact fixtures for Lunar New Year, the 2023 leap second month, Dragon
+  Boat Festival, Mid-Autumn Festival, reverse conversions, festival lookup,
+  and the Rabbit-to-Dragon zodiac boundary.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,9 +39,10 @@ dependencies = [
     "skyfield>=1.48",
     "ephem>=4.1.5",
     "astropy>=6.0.0",
-    "lunardate>=0.2.2",
-    "zhdate>=0.1",
-    "chinese-calendar>=1.9.0",
+    "lunardate>=0.3.0,<0.4",
+    # PyPI's zhdate 1.0 sdist has invalid/unresolvable package metadata.
+    "zhdate==0.1",
+    "chinese-calendar>=1.11.0,<2",
 ]
 
 [project.urls]

--- a/src/lunar_mcp_server/calendar_conversions.py
+++ b/src/lunar_mcp_server/calendar_conversions.py
@@ -185,7 +185,7 @@ class CalendarConverter:
 
             if LUNARDATE_AVAILABLE:
                 try:
-                    lunar_date = LunarDate.fromSolarDate(
+                    lunar_date = LunarDate.from_solar_date(
                         solar_date.year, solar_date.month, solar_date.day
                     )
                     zodiac_info = self._calculate_chinese_zodiac_year(lunar_date.year)
@@ -263,7 +263,7 @@ class CalendarConverter:
             if LUNARDATE_AVAILABLE:
                 try:
                     lunar_date = LunarDate(lunar_year, lunar_month, lunar_day)
-                    solar_date = lunar_date.toSolarDate()
+                    solar_date = lunar_date.to_solar_date()
 
                     result.update(
                         {

--- a/tests/test_calendar_golden.py
+++ b/tests/test_calendar_golden.py
@@ -1,0 +1,82 @@
+"""Golden Chinese calendar and festival fixtures."""
+
+import pytest
+
+from lunar_mcp_server.calendar_conversions import CalendarConverter
+from lunar_mcp_server.festivals import FestivalManager
+
+SOLAR_TO_LUNAR_CASES = [
+    ("2023-03-21", (2023, 2, 30, False)),
+    ("2023-03-22", (2023, 2, 1, True)),
+    ("2023-04-19", (2023, 2, 29, True)),
+    ("2023-04-20", (2023, 3, 1, False)),
+    ("2024-02-09", (2023, 12, 30, False)),
+    ("2024-02-10", (2024, 1, 1, False)),
+    ("2024-06-10", (2024, 5, 5, False)),
+    ("2024-09-17", (2024, 8, 15, False)),
+    ("2025-01-28", (2024, 12, 29, False)),
+    ("2025-01-29", (2025, 1, 1, False)),
+]
+
+LUNAR_TO_SOLAR_CASES = [
+    ("2024-1-1", "2024-02-10"),
+    ("2024-5-5", "2024-06-10"),
+    ("2024-8-15", "2024-09-17"),
+    ("2025-1-1", "2025-01-29"),
+]
+
+FESTIVAL_CASES = [
+    ("2024-02-10", "Spring Festival (Chinese New Year)"),
+    ("2024-06-10", "Dragon Boat Festival"),
+    ("2024-09-17", "Mid-Autumn Festival"),
+    ("2025-01-29", "Spring Festival (Chinese New Year)"),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("solar_date", "expected"), SOLAR_TO_LUNAR_CASES)
+async def test_solar_to_lunar_boundaries(
+    solar_date: str, expected: tuple[int, int, int, bool]
+) -> None:
+    """Preserve new-year, leap-month, and major-festival conversions."""
+    result = await CalendarConverter().solar_to_lunar(solar_date)
+
+    assert "error" not in result
+    actual = (
+        result["lunar_year"],
+        result["lunar_month"],
+        result["lunar_day"],
+        result["is_leap_month"],
+    )
+    assert actual == expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("lunar_date", "solar_date"), LUNAR_TO_SOLAR_CASES)
+async def test_lunar_to_solar_major_dates(lunar_date: str, solar_date: str) -> None:
+    """Preserve reverse conversion for major lunar dates across years."""
+    result = await CalendarConverter().lunar_to_solar(lunar_date)
+
+    assert "error" not in result
+    assert result["solar_date"] == solar_date
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("solar_date", "festival_name"), FESTIVAL_CASES)
+async def test_major_festival_dates(solar_date: str, festival_name: str) -> None:
+    """Preserve the validated Gregorian dates of major lunar festivals."""
+    result = await FestivalManager().get_festivals_for_date(solar_date)
+
+    assert "error" not in result
+    assert festival_name in {festival["name"] for festival in result["festivals"]}
+
+
+@pytest.mark.asyncio
+async def test_zodiac_boundary_follows_lunar_new_year() -> None:
+    """Preserve the Rabbit-to-Dragon boundary across Lunar New Year 2024."""
+    converter = CalendarConverter()
+    before = await converter.solar_to_lunar("2024-02-09")
+    after = await converter.solar_to_lunar("2024-02-10")
+
+    assert before["zodiac_info"]["animal"] == "Rabbit"
+    assert after["zodiac_info"]["animal"] == "Dragon"

--- a/uv.lock
+++ b/uv.lock
@@ -283,11 +283,11 @@ wheels = [
 
 [[package]]
 name = "chinese-calendar"
-version = "1.10.0"
+version = "1.11.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1d/a7/02eef814abac2a95c1484b4812dce4b57976c9b23e9321eecf313ae31d5c/chinese_calendar-1.10.0.tar.gz", hash = "sha256:1e8c731fb21f79249becfdfff55bf097a7163e3ca76fb5b8107c499cc873ac42", size = 17375, upload-time = "2024-11-13T05:43:23.357Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a0/af/d5dd356a7d03d17325a2f3100e35d26300a405bc7d57d3325dd634f04cc2/chinese_calendar-1.11.0.tar.gz", hash = "sha256:931d9187cbf7bb1dc09685dedb5013e74678bbe03a173d71d46b76afc37f2597", size = 16607, upload-time = "2025-11-04T10:22:43.64Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/72/56fab8f101adc358a42fa5acb26e2c5b989e97f1900ea7d6bd29334b432e/chinese_calendar-1.10.0-py2.py3-none-any.whl", hash = "sha256:9ab1b535a2c41edb0d48a43762c314b51b9ffb36c19e7cd3963b306a20ba30c6", size = 11851, upload-time = "2024-11-13T05:43:21.655Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/34/5ba74e1c2509c522dc9bbc7ff07f2a9823c51183ef32ec2dbade1c593205/chinese_calendar-1.11.0-py2.py3-none-any.whl", hash = "sha256:6800bf53bd011a8b3e9fbb91805d16210f59648c2d86130dc43c2aa7708207ec", size = 11226, upload-time = "2025-11-04T10:22:41.935Z" },
 ]
 
 [[package]]
@@ -736,12 +736,12 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "astropy", specifier = ">=6.0.0" },
-    { name = "chinese-calendar", specifier = ">=1.9.0" },
+    { name = "chinese-calendar", specifier = ">=1.11.0,<2" },
     { name = "ephem", specifier = ">=4.1.5" },
-    { name = "lunardate", specifier = ">=0.2.2" },
+    { name = "lunardate", specifier = ">=0.3.0,<0.4" },
     { name = "mcp", specifier = ">=1.28.1,<2" },
     { name = "skyfield", specifier = ">=1.48" },
-    { name = "zhdate", specifier = ">=0.1" },
+    { name = "zhdate", specifier = "==0.1" },
 ]
 
 [package.metadata.requires-dev]
@@ -757,11 +757,11 @@ dev = [
 
 [[package]]
 name = "lunardate"
-version = "0.2.2"
+version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/85/71/62fadf243502618cf2a7af5b81936a99684147c655729934f014758c3b39/lunardate-0.2.2.tar.gz", hash = "sha256:8ff8c01721bef7710f0712a302b1cb7d0b8b3ffc72a63a9a056cd01e58e5485a", size = 17686, upload-time = "2023-12-07T13:13:21.09Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4a/70/6d4d14313b5d9eab05e37c761164dd572d95386bd6238354b04b989e0eae/lunardate-0.3.0.tar.gz", hash = "sha256:ae1daa9140bb1078b2c8e2a5b1623e6f25cf0443eca9ef2d6df27a4644f25fef", size = 18571, upload-time = "2026-07-07T05:05:39.019Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/07/232401bb1c6bc699c5e641ad375e2582cdde90b19b18e6618ec51796b737/lunardate-0.2.2-py3-none-any.whl", hash = "sha256:cf1916337e50470a82df12d885ff47a456e89c91a3ad4e5fdf1575e063a7ed55", size = 18081, upload-time = "2023-12-07T13:13:19.333Z" },
+    { url = "https://files.pythonhosted.org/packages/13/65/b0f833b26f932c865efd25790960bb83481098d66ed8b4ceac8a91859433/lunardate-0.3.0-py3-none-any.whl", hash = "sha256:68c1beaf7704c55c8a2c929d14be3ca98da55992d0ec3c0dd57eae2a5d4079fb", size = 18784, upload-time = "2026-07-07T05:05:38.029Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- upgrade `lunardate` 0.2.2 → 0.3.0
- upgrade `chinese-calendar` 1.10.0 → 1.11.0
- intentionally retain/pin `zhdate` 0.1 because PyPI's 1.0 sdist is not resolvable as version 1.0 by uv
- migrate to the non-deprecated lunardate snake_case conversion APIs
- add exact golden fixtures for Lunar New Year, the 2023 leap second month, major festivals, reverse conversions, and the lunar-year zodiac boundary

## Output validation
The new golden values were captured before the upgrade and pass unchanged after it. No expected application output was rewritten to accommodate the dependency updates.

## Validation
- `uv lock --check`
- `uv sync --frozen`
- `uv audit --frozen` (no known vulnerabilities)
- `uv run black --check src tests`
- `uv run ruff check src tests`
- `uv run mypy src`
- `uv run pytest -W error::DeprecationWarning` (206 passed)
- `uv run pre-commit run --all-files`
- `uv build`

Closes #18
