### PR TITLE
ci: validate Python 3.11–3.14 compatibility

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -12,20 +12,16 @@ This workflow runs code quality checks and tests on every pull request and push 
    - Ruff linting
    - Mypy type checking
 
-2. **Unit Tests** (runs in parallel after quality checks)
-   - Runs pytest with coverage
-   - Tests all Python modules
-   - Generates coverage reports
-   - Uploads coverage artifact
+2. **Test Matrix** (runs in parallel after quality checks)
+   - Runs the full unit and integration suite on standard CPython 3.11–3.14
+   - Validates all 20 tools, 5 prompts, and 5 resources on every version
+   - Generates and uploads coverage once, from Python 3.11
 
-3. **MCP Server Tests** (runs in parallel after quality checks)
-   - Runs comprehensive MCP server tests
-   - Validates all 20 tools, 5 prompts, and 5 resources
-   - Uses `./scripts/test_mcp_final.sh`
-
-4. **Test Matrix** (runs in parallel after quality checks)
-   - Tests on Python 3.11 and 3.12
-   - Ensures compatibility across versions
+3. **Built Artifact Tests** (runs in parallel after quality checks)
+   - Builds both the wheel and source distribution
+   - Installs each artifact in an isolated environment on Python 3.11 and 3.14
+   - Smoke-tests version metadata, server construction, and bundled ephemeris
+     access from outside the repository
 
 ### Triggers
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: "3.11"
 
       - name: Install dependencies
         run: uv sync --dev
@@ -41,86 +41,14 @@ jobs:
       - name: Type check with mypy
         run: uv run mypy src/
 
-  unit-tests:
-    name: Unit Tests
-    runs-on: ubuntu-latest
-    needs: code-quality
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v4
-        with:
-          enable-cache: true
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-
-      - name: Install dependencies
-        run: uv sync --dev
-
-      - name: Download astronomical data
-        run: |
-          python -c "from skyfield.api import load; load('de421.bsp')" || true
-
-      - name: Run unit tests with pytest
-        run: uv run pytest --cov --cov-report=xml --cov-report=term
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
-        with:
-          file: ./coverage.xml
-          flags: unittests
-          name: codecov-umbrella
-          fail_ci_if_error: false
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
-      - name: Upload coverage to artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-report
-          path: coverage.xml
-
-  mcp-tests:
-    name: MCP Server Tests
-    runs-on: ubuntu-latest
-    needs: code-quality
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v4
-        with:
-          enable-cache: true
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-
-      - name: Install dependencies
-        run: uv sync --dev
-
-      - name: Make test script executable
-        run: chmod +x ./scripts/test_mcp_final.sh
-
-      - name: Run comprehensive MCP server tests
-        run: ./scripts/test_mcp_final.sh
-
   test-matrix:
     name: Test on Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     needs: code-quality
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ['3.11', '3.12']
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - name: Checkout code
@@ -139,5 +67,94 @@ jobs:
       - name: Install dependencies
         run: uv sync --dev
 
-      - name: Run tests
-        run: uv run pytest -v
+      - name: Run unit and MCP integration tests
+        run: uv run pytest -W error::DeprecationWarning
+
+      - name: Upload Python 3.11 coverage to Codecov
+        if: matrix.python-version == '3.11'
+        uses: codecov/codecov-action@v4
+        with:
+          file: ./coverage.xml
+          flags: unittests
+          name: codecov-umbrella
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Upload Python 3.11 coverage artifact
+        if: matrix.python-version == '3.11'
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage.xml
+
+  artifact-tests:
+    name: Artifact install on Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    needs: code-quality
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.14"]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Build wheel and source distribution
+        run: uv build
+
+      - name: Install wheel in a clean environment
+        run: |
+          uv venv --python "${{ matrix.python-version }}" .venv-wheel
+          uv pip install --python .venv-wheel/bin/python dist/*.whl
+
+      - name: Smoke-test installed wheel outside the repository
+        run: |
+          temp_dir="$(mktemp -d)"
+          cd "$temp_dir"
+          "$GITHUB_WORKSPACE/.venv-wheel/bin/python" - <<'PY'
+          import asyncio
+          from importlib.metadata import version
+
+          from lunar_mcp_server import __version__
+          from lunar_mcp_server.lunar_calculations import LunarCalculator
+          from lunar_mcp_server.server import LunarMCPServer
+
+          assert __version__ == version("lunar-mcp-server")
+          server = LunarMCPServer()
+          assert server is not None
+          result = asyncio.run(LunarCalculator().get_moon_phase("2024-03-25"))
+          assert result["illumination"] == 0.001
+          PY
+
+      - name: Install source distribution in a clean environment
+        run: |
+          uv venv --python "${{ matrix.python-version }}" .venv-sdist
+          uv pip install --python .venv-sdist/bin/python dist/*.tar.gz
+
+      - name: Smoke-test installed source distribution outside the repository
+        run: |
+          temp_dir="$(mktemp -d)"
+          cd "$temp_dir"
+          "$GITHUB_WORKSPACE/.venv-sdist/bin/python" - <<'PY'
+          import asyncio
+          from importlib.metadata import version
+
+          from lunar_mcp_server import __version__
+          from lunar_mcp_server.lunar_calculations import LunarCalculator
+
+          assert __version__ == version("lunar-mcp-server")
+          result = asyncio.run(LunarCalculator().get_moon_phase("2024-03-25"))
+          assert result["illumination"] == 0.001
+          PY

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@
 
 </div>
 
+Standard CPython 3.11, 3.12, 3.13, and 3.14 are supported and tested. Python
+3.14 free-threaded builds are not part of the v1.2.1 support guarantee.
+
 ## 📖 Overview
 
 A comprehensive Model Context Protocol (MCP) server providing traditional Chinese lunar calendar information, auspicious date checking, and festival data based on Chinese cultural traditions.

--- a/docs/development.md
+++ b/docs/development.md
@@ -6,7 +6,7 @@ Guide for contributing to the Lunar Calendar MCP Server.
 
 ### Prerequisites
 
-- Python 3.11 or higher
+- Standard CPython 3.11–3.14 (free-threaded builds are not currently tested)
 - [uv](https://github.com/astral-sh/uv) (recommended) or pip
 - Git
 

--- a/docs/python-support-v1.2.1.md
+++ b/docs/python-support-v1.2.1.md
@@ -1,0 +1,36 @@
+# Python support validation for v1.2.1
+
+Issue #14 validates the modernized dependency resolution on standard CPython
+3.11, 3.12, 3.13, and 3.14. The package continues to declare
+`requires-python = ">=3.11"` and now advertises each tested version with a PyPI
+classifier.
+
+## CI evidence
+
+The test matrix runs the complete 216-test suite on all four versions. This
+includes production-STDIO integration coverage that discovers and exercises all
+20 tools, 5 prompts, and 5 resources under both the current and legacy MCP
+protocol initialization paths.
+
+Separate artifact jobs cover the oldest and newest supported interpreters,
+Python 3.11 and 3.14. Each job:
+
+1. builds both the wheel and source distribution;
+2. installs each artifact into its own empty virtual environment;
+3. changes to a directory outside the source checkout;
+4. verifies installed version metadata and server construction; and
+5. performs a calculation using the ephemeris bundled in the artifact.
+
+Formatting, linting, and type checking run once on Python 3.11 instead of being
+duplicated across the matrix.
+
+## Dependency compatibility
+
+The universal `uv.lock` resolves successfully for every tested interpreter.
+Notably, the astronomy resolution selects NumPy 2.4.6 on Python 3.11 and NumPy
+2.5.1 on Python 3.12–3.14, while Ephem 4.2.1 supplies standard CPython wheels
+through Python 3.14. No package blocks the supported matrix.
+
+Python 3.14 free-threaded builds are explicitly deferred because this patch
+tests only standard CPython builds. Unreleased Python versions are not
+advertised.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,8 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Scientific/Engineering :: Astronomy",
     "Topic :: Religion",


### PR DESCRIPTION
Closes #14

## Summary
- run the complete unit and production-STDIO integration suite on standard CPython 3.11–3.14
- remove redundant test jobs while retaining one Python 3.11 quality job
- build and clean-install both wheel and sdist on Python 3.11 and 3.14
- smoke-test installed metadata, server construction, calculations, and bundled ephemeris outside the checkout
- add confirmed Python 3.13/3.14 classifiers and document the tested support range and free-threaded deferral

## Validation
- 216 tests pass locally on each of Python 3.11, 3.12, 3.13, and 3.14 with deprecations treated as errors
- wheel and sdist clean-install smoke tests pass locally on Python 3.11 and 3.14
- pre-commit passes
- `uv lock --check` and `uv audit --frozen` pass
- workflow YAML parses successfully