### PR TITLE
ci(deps): add uv-native dependency automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,115 @@
+version: 2
+
+# Weekly checks keep review volume manageable. Patch/minor updates can be
+# grouped only inside their risk domain; majors remain individual PRs.
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Taipei"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      core-runtime:
+        patterns:
+          - "annotated-types"
+          - "anyio"
+          - "attrs"
+          - "certifi"
+          - "cffi"
+          - "click"
+          - "cryptography"
+          - "h11"
+          - "hatchling"
+          - "httpcore"
+          - "httpx"
+          - "httpx-sse"
+          - "idna"
+          - "jsonschema*"
+          - "packaging"
+          - "pydantic*"
+          - "pycparser"
+          - "pyjwt"
+          - "python-dotenv"
+          - "python-multipart"
+          - "referencing"
+          - "rpds-py"
+          - "sniffio"
+          - "sse-starlette"
+          - "starlette"
+          - "typing-*"
+          - "uvicorn"
+        update-types:
+          - "minor"
+          - "patch"
+      astronomy-runtime:
+        patterns:
+          - "ephem"
+          - "jplephem"
+          - "numpy"
+          - "sgp4"
+          - "skyfield"
+        update-types:
+          - "minor"
+          - "patch"
+      chinese-calendar-runtime:
+        patterns:
+          - "chinese-calendar"
+          - "lunardate"
+          - "zhdate"
+        update-types:
+          - "minor"
+          - "patch"
+      development-tools:
+        dependency-type: "development"
+        patterns:
+          - "black"
+          - "coverage"
+          - "distlib"
+          - "filelock"
+          - "identify"
+          - "iniconfig"
+          - "mypy"
+          - "mypy-extensions"
+          - "nodeenv"
+          - "pathspec"
+          - "platformdirs"
+          - "pluggy"
+          - "pre-commit"
+          - "pygments"
+          - "pytest*"
+          - "pytokens"
+          - "ruff"
+          - "virtualenv"
+        update-types:
+          - "minor"
+          - "patch"
+    # `mcp` is deliberately absent from every group so SDK updates always get
+    # an independent protocol-focused pull request.
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:30"
+      timezone: "Asia/Taipei"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "ci(deps)"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -6,18 +6,25 @@ This workflow runs code quality checks and tests on every pull request and push 
 
 ### Workflow Jobs
 
-1. **Code Quality Checks** (runs first)
+1. **Lockfile and Vulnerability Validation** (runs first)
+   - Confirms `pyproject.toml` and `uv.lock` are consistent
+   - Installs without changing the lockfile
+   - Audits the complete frozen dependency graph
+
+2. **Code Quality Checks** (runs after dependency validation)
    - Black formatting validation
    - Ruff lint and import-sorting validation
    - Ruff linting
    - Mypy type checking
 
-2. **Test Matrix** (runs in parallel after quality checks)
+All subsequent uv installs and tool runs are also frozen.
+
+3. **Test Matrix** (runs in parallel after quality checks)
    - Runs the full unit and integration suite on standard CPython 3.11–3.14
    - Validates all 20 tools, 5 prompts, and 5 resources on every version
    - Generates and uploads coverage once, from Python 3.11
 
-3. **Built Artifact Tests** (runs in parallel after quality checks)
+4. **Built Artifact Tests** (runs in parallel after quality checks)
    - Builds both the wheel and source distribution
    - Installs each artifact in an isolated environment on Python 3.11 and 3.14
    - Smoke-tests version metadata, server construction, and bundled ephemeris
@@ -35,6 +42,10 @@ No setup required - the workflow runs automatically when:
 - You push commits to main/develop branches
 
 All PR checks must pass before the PR can be merged (if branch protection is enabled).
+
+`dependency-review.yaml` runs only for pull requests and rejects newly
+introduced vulnerable dependencies. Dependabot policy and repository security
+settings are documented in [`docs/dependency-automation.md`](../../docs/dependency-automation.md).
 
 ## publish.yaml - PyPI Publishing Workflow
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,8 +11,8 @@ on:
       - develop
 
 jobs:
-  code-quality:
-    name: Code Quality Checks
+  dependency-validation:
+    name: Lockfile and Vulnerability Validation
     runs-on: ubuntu-latest
 
     steps:
@@ -29,17 +29,45 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Verify lockfile is current
+        run: uv lock --check
+
+      - name: Install exactly from the lockfile
+        run: uv sync --frozen
+
+      - name: Audit the locked dependency graph
+        run: uv audit --frozen
+
+  code-quality:
+    name: Code Quality Checks
+    runs-on: ubuntu-latest
+    needs: dependency-validation
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
       - name: Install dependencies
-        run: uv sync --dev
+        run: uv sync --frozen
 
       - name: Check code formatting with black
-        run: uv run black --check src/ tests/
+        run: uv run --frozen black --check src/ tests/
 
       - name: Lint with ruff
-        run: uv run ruff check src/ tests/
+        run: uv run --frozen ruff check src/ tests/
 
       - name: Type check with mypy
-        run: uv run mypy src/
+        run: uv run --frozen mypy src/
 
   test-matrix:
     name: Test on Python ${{ matrix.python-version }}
@@ -65,10 +93,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: uv sync --dev
+        run: uv sync --frozen
 
       - name: Run unit and MCP integration tests
-        run: uv run pytest -W error::DeprecationWarning
+        run: uv run --frozen pytest -W error::DeprecationWarning
 
       - name: Upload Python 3.11 coverage to Codecov
         if: matrix.python-version == '3.11'

--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -1,0 +1,23 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches:
+      - main
+      - develop
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    name: Dependency Review
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Reject newly introduced vulnerable dependencies
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: low

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -25,16 +25,16 @@ jobs:
           python-version: "3.11"
 
       - name: Install dependencies
-        run: uv sync --dev
+        run: uv sync --frozen
 
       - name: Check code formatting with black
-        run: uv run black --check src/ tests/
+        run: uv run --frozen black --check src/ tests/
 
       - name: Lint with ruff
-        run: uv run ruff check src/ tests/
+        run: uv run --frozen ruff check src/ tests/
 
       - name: Type check with mypy
-        run: uv run mypy src/
+        run: uv run --frozen mypy src/
 
   tests:
     name: Run Test Suite
@@ -54,7 +54,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install dependencies
-        run: uv sync --dev
+        run: uv sync --frozen
 
       - name: Run comprehensive MCP server tests
         run: |
@@ -62,7 +62,7 @@ jobs:
           ./scripts/test_mcp_final.sh
 
       - name: Run unit tests with pytest
-        run: uv run pytest --cov --cov-report=xml
+        run: uv run --frozen pytest --cov --cov-report=xml
 
       - name: Upload coverage reports
         uses: codecov/codecov-action@v4

--- a/docs/dependency-automation.md
+++ b/docs/dependency-automation.md
@@ -1,0 +1,64 @@
+# Dependency automation
+
+The repository uses Dependabot's native `uv` ecosystem to update
+`pyproject.toml` and `uv.lock` together. GitHub Actions are monitored by a
+separate ecosystem entry.
+
+## Schedule and pull-request limits
+
+- uv checks run weekly on Monday at 09:00 `Asia/Taipei`, with at most 10 open
+  version-update pull requests.
+- GitHub Actions checks run weekly on Monday at 09:30 `Asia/Taipei`, with at
+  most 5 open version-update pull requests.
+- uv pull requests receive the `dependencies` label. Actions pull requests also
+  receive `github-actions`.
+- Automatic merging is intentionally disabled. Every update receives the same
+  CI and review as a human-authored pull request.
+
+## Grouping policy
+
+Only patch and minor updates are grouped. Major updates remain individual.
+
+- `mcp` is excluded from all groups so SDK and protocol changes are reviewed in
+  isolation.
+- Core runtime utilities, astronomy packages, and Chinese calendar packages use
+  distinct groups.
+- Development-tool patch/minor updates can share one pull request.
+- GitHub Actions patch/minor updates can share one pull request.
+
+Required transitive lockfile changes travel with the applicable direct update.
+An update must not combine MCP, core runtime, astronomy, and Chinese calendar
+domains merely to make dependency resolution easier.
+
+## Pull-request gates
+
+The first CI job runs these commands before quality, compatibility, or artifact
+jobs:
+
+```bash
+uv lock --check
+uv sync --frozen
+uv audit --frozen
+```
+
+All later project installs and `uv run` commands are frozen, so CI cannot repair
+or rewrite an inconsistent lockfile. The complete test matrix continues to run
+on Python 3.11–3.14, including the production STDIO MCP integration suite, and
+artifact jobs continue to clean-install the wheel and sdist on Python 3.11 and
+3.14.
+
+A pull-request-only dependency-review workflow rejects any newly introduced
+known vulnerability. `uv audit` separately audits the complete locked graph.
+There is no advisory allow-list; an exception would require a documented change
+reviewed in a pull request.
+
+## Repository settings
+
+Dependabot alerts and Dependabot security updates are enabled in repository
+settings. The public repository's dependency graph enables GitHub dependency
+review. Maintainers can verify these settings under **Settings → Code security**.
+
+The configuration is validated after it reaches the default branch by checking
+the Dependabot update log or the first generated update pull request. If GitHub
+reports a configuration error, dependency automation is not considered healthy
+until that error is corrected.


### PR DESCRIPTION
Closes #15

## Summary
- configure weekly native-uv and separate GitHub Actions Dependabot updates
- isolate MCP, core runtime, astronomy, Chinese calendar, development-tool, and Actions update domains; group only patch/minor updates
- add an early lockfile/frozen-install/vulnerability gate before expensive CI jobs
- make all later CI and release installs/tool runs frozen
- add pull-request dependency review with no advisory allow-list
- document schedules, PR limits, labels, grouping, gates, and security settings
- enable Dependabot alerts/security updates in repository settings and create the configured labels

## Validation
- Dependabot configuration passes the current SchemaStore Dependabot v2 schema
- all workflow YAML parses successfully
- `uv lock --check`, `uv sync --frozen`, and `uv audit --frozen` pass
- full suite passes (216 tests, warnings treated as errors)
- pre-commit passes

After this configuration reaches `main`, I will verify the initial Dependabot update run/opened PR before completing the issue.